### PR TITLE
Needs GHC >= 7.6 due to System.Environment.lookupEnv

### DIFF
--- a/tinylog.cabal
+++ b/tinylog.cabal
@@ -35,7 +35,7 @@ library
         System.Logger.Settings
 
     build-depends:
-          base              == 4.*
+          base              >= 4.6    && < 5
         , bytestring        >= 0.10.4 && < 1.0
         , auto-update       >= 0.1    && < 0.2
         , containers        >= 0.5


### PR DESCRIPTION
I've revised current versions (http://hackage.haskell.org/package/tinylog/revisions/) so a new release is only needed if you want to support older GHCs.
